### PR TITLE
Check if image was deleted during processing.

### DIFF
--- a/tariffsdk/src/main/java/net/gini/tariffsdk/DocumentServiceImpl.java
+++ b/tariffsdk/src/main/java/net/gini/tariffsdk/DocumentServiceImpl.java
@@ -73,7 +73,7 @@ class DocumentServiceImpl implements DocumentService {
 
     @Override
     public void keepImage(@NonNull final Uri uri) {
-        //TODO - start processing
+        //TODO - start processing, the whole thing is just a mock.
         final Image image = new Image(uri, ImageState.PROCESSING);
         if (!mImageList.contains(image)) {
             new Thread(new Runnable() {
@@ -84,11 +84,13 @@ class DocumentServiceImpl implements DocumentService {
                     } catch (InterruptedException e) {
                         e.printStackTrace();
                     }
-                    //Pseudo mock states
-                    image.setProcessingState(
-                            new Random().nextBoolean() ? ImageState.SUCCESSFULLY_PROCESSED
-                                    : ImageState.FAILED);
-                    imageProcessed(image);
+                    if (mImageList.contains(image)) {
+                        //Pseudo mock states
+                        image.setProcessingState(
+                                new Random().nextBoolean() ? ImageState.SUCCESSFULLY_PROCESSED
+                                        : ImageState.FAILED);
+                        imageProcessed(image);
+                    }
                 }
             }).start();
 


### PR DESCRIPTION
## Prevent updating when the image has been deleted
## Information
when an image was deleted and the mock background task tried to update it's state it crashed.
this is just a temporary fix since the whole method will be replaced when we talk to our backend. Just for now that there are less crashes.
## How to test
run the sample app
## Merge information
none