### PR TITLE
Updated the support lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Please note that if you are using our SDK together with our API (under a license
 
 
 ### Third party libraries
-[okHttp](http://square.github.io/okhttp/)
+- [okHttp v3.6.0](http://square.github.io/okhttp/)
+- [Android Support Library v26.0.1](https://developer.android.com/topic/libraries/support-library/revisions.html#26-0-1)
+(If you have troubles regarding your support library version and Gini Switch's version you can find different solutions suggested in the [documentation](http://developer.gini.net/gini-switch-sdk-android/pages/integration.html#dependencies).)
 
 ### License
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,9 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com'
+        }
     }
     tasks.withType(Javadoc) {
         options.addStringOption('Xdoclint:none', '-quiet')
@@ -27,15 +30,15 @@ task clean(type: Delete) {
 }
 
 ext {
-    buildToolsVersion = '25.0.2'
-    compileSdkVersion = 25
+    buildToolsVersion = '26.0.1'
+    compileSdkVersion = 26
     minSdkVersion = 16
-    targetSdkVersion = 25
+    targetSdkVersion = 26
 
     versionCode = 1
     versionName = '0.0.0'
 
-    supportLibraryVersion = '25.2.0'
+    supportLibraryVersion = '26.0.1'
     junitVersion = '4.12'
     okhttpVersion = '3.6.0'
 }

--- a/documentation/pages/integration.rst
+++ b/documentation/pages/integration.rst
@@ -40,8 +40,8 @@ The Switch SDK is using the external Http library `okHttp <https://github.com/sq
 As well as the `Android Support Library <https://developer.android.com/topic/libraries/support-library/index.html>`_ version 26.0.1.
 
 If your project is using a different kind of the support library problems can appear during run- or compile time.
-You have different options to address this problems. The easist solution is probably that you are using the same version as the SDK. If we update the SDK we tend to update the used support library as well to the latest version.
-However if you want to use another support library version you can do so by forcing the same support library version to all your used libraries. This can be done with the following gradle method:
+You have different options to address this problems. The easiest solution is probably to use the same version as the SDK. If we update the SDK we tend to update the used support library as well to the latest version.
+However if you want to use another support library version you can do so by forcing the same support library version on all your used libraries. This can be done with the following gradle method:
 
 .. code-block:: groovy
 

--- a/documentation/pages/integration.rst
+++ b/documentation/pages/integration.rst
@@ -31,3 +31,29 @@ Hereby a Context, your client id, your client secret and your domain is needed(F
   final SwitchSdk switchSdk = SwitchSdk.init(this, "clientId", "clientPw", "domain");
 
 The generated SwitchSdk instance can now be used to generate the needed Activity and to get the found extractions.
+
+
+Dependencies
+============
+
+The Switch SDK is using the external Http library `okHttp <https://github.com/square/okhttp>`_ version 3.6.0.
+As well as the `Android Support Library <https://developer.android.com/topic/libraries/support-library/index.html>`_ version 26.0.1.
+
+If your project is using a different kind of the support library problems can appear during run- or compile time.
+You have different options to address this problems. The easist solution is probably that you are using the same version as the SDK. If we update the SDK we tend to update the used support library as well to the latest version.
+However if you want to use another support library version you can do so by forcing the same support library version to all your used libraries. This can be done with the following gradle method:
+
+.. code-block:: groovy
+
+  configurations.all {
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        def requested = details.requested
+        if (requested.group == 'com.android.support') {
+            if (!requested.name.startsWith("multidex")) {
+                details.useVersion 'dessired-support-lib-version'
+            }
+        }
+    }
+  }
+
+.. note:: We only test the Gini Switch SDK with the support library version which is used in the library. Problems occuring related to forcing another library version might not be solvable by us.

--- a/sample/src/main/java/net/gini/switchsdk/sample/MainActivity.java
+++ b/sample/src/main/java/net/gini/switchsdk/sample/MainActivity.java
@@ -33,10 +33,7 @@ public class MainActivity extends BaseActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        HttpLoggingInterceptor interceptor = new HttpLoggingInterceptor();
-        interceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
         final OkHttpClient okHttpClient = new OkHttpClient.Builder()
-                .addNetworkInterceptor(interceptor)
                 .build();
 
         mSwitchSdk = SwitchSdk.init(this, BuildConfig.CLIENT_ID, BuildConfig.CLIENT_SECRET,


### PR DESCRIPTION
## Updated the support lib
## Information
Support libs are more or less incompatible in Android. So if you create a new project from scratch Android Studio uses the latest support library in your project. This is right now 26.0.1. The SDK uses 25.2.0. Therefore the app crashed due to incompatibility. The library has been updated now and a section about this added in the documentation if this occurs again.
## How to test
make a project and use different support lib version
## Merge information
none