### PR TITLE
Bugfix/pinch to zoom

### DIFF
--- a/switchsdk/src/main/java/net/gini/switchsdk/utils/ZoomImageView.java
+++ b/switchsdk/src/main/java/net/gini/switchsdk/utils/ZoomImageView.java
@@ -77,22 +77,15 @@ public class ZoomImageView extends android.support.v7.widget.AppCompatImageView 
                 mStartTouch.set(mLastTouch);
                 mMode = Mode.DRAG;
                 break;
-            //when two fingers are touching
-            case MotionEvent.ACTION_POINTER_DOWN:
-                mLastTouch.set(event.getX(), event.getY());
-                mStartTouch.set(mLastTouch);
-                mMode = Mode.ZOOM;
-                break;
-            //when a finger moves
             //If mode is applicable move image
             case MotionEvent.ACTION_MOVE:
 
-                //if the mode is ZOOM or
                 //if the mode is DRAG and already zoomed
-                if (mMode == Mode.ZOOM || (mMode == Mode.DRAG && mSaveScale > MIN_SCALE)) {
+                if (mMode == Mode.DRAG && mSaveScale > MIN_SCALE) {
 
                     float deltaX = currentPoint.x - mLastTouch.x;// x difference
                     float deltaY = currentPoint.y - mLastTouch.y;// y difference
+
                     float scaleWidth = Math.round(
                             mOriginalBitmapWidth * mSaveScale);// width after applying current scale
                     float scaleHeight = Math.round(mOriginalBitmapHeight
@@ -133,10 +126,6 @@ public class ZoomImageView extends android.support.v7.widget.AppCompatImageView 
                 if (xDiff < MAX_DIFF_FOR_CLICK && yDiff < MAX_DIFF_FOR_CLICK) {
                     performClick();
                 }
-                break;
-            // second finger is lifted
-            case MotionEvent.ACTION_POINTER_UP:
-                mMode = Mode.NONE;
                 break;
         }
         setImageMatrix(mMatrix);

--- a/switchsdk/src/main/java/net/gini/switchsdk/utils/ZoomImageView.java
+++ b/switchsdk/src/main/java/net/gini/switchsdk/utils/ZoomImageView.java
@@ -178,7 +178,7 @@ public class ZoomImageView extends android.support.v7.widget.AppCompatImageView 
     }
 
     private enum Mode {
-        NONE, DRAG, ZOOM
+        NONE, DRAG
     }
 
     private class ScaleListener extends ScaleGestureDetector.SimpleOnScaleGestureListener {
@@ -209,7 +209,6 @@ public class ZoomImageView extends android.support.v7.widget.AppCompatImageView 
 
         @Override
         public boolean onScaleBegin(ScaleGestureDetector detector) {
-            mMode = Mode.ZOOM;
             return true;
         }
 


### PR DESCRIPTION
## Zoom function
## Information
Zooming wasn't correct and when you moved your fingers always the centre of one finger was zoomed in not the centre between the two fingers. See #73 
Problem was that the correct way would be using the ScaleGestureDetector, that was done but it was also overwritten with some wrong implementation. This have been removed now.
## How to test
zoom
## Merge information
none