### PR TITLE
Added zoom mode to determine if the user zooms or drags

### DIFF
--- a/switchsdk/src/main/java/net/gini/switchsdk/utils/ZoomImageView.java
+++ b/switchsdk/src/main/java/net/gini/switchsdk/utils/ZoomImageView.java
@@ -178,13 +178,14 @@ public class ZoomImageView extends android.support.v7.widget.AppCompatImageView 
     }
 
     private enum Mode {
-        NONE, DRAG
+        NONE, DRAG, ZOOM
     }
 
     private class ScaleListener extends ScaleGestureDetector.SimpleOnScaleGestureListener {
 
         @Override
         public boolean onScale(ScaleGestureDetector detector) {
+            mMode = Mode.ZOOM;
             float scaleFactor = detector.getScaleFactor();
             float newScale = mSaveScale * scaleFactor;
             if (newScale < MAX_SCALE && newScale > MIN_SCALE) {


### PR DESCRIPTION
## Added zoom mode
## Information
Turns out the Zoom mode was there for a reason, so that in the ontouch zooming isn't interpreted as dragging
## How to test
zoom
## Merge information
none