### PR TITLE
Only pro-actively exit if the user has taken the next photo

### DIFF
--- a/switchsdk/src/main/java/net/gini/switchsdk/ReviewPictureActivity.java
+++ b/switchsdk/src/main/java/net/gini/switchsdk/ReviewPictureActivity.java
@@ -31,6 +31,8 @@ final public class ReviewPictureActivity extends SwitchSdkBaseActivity implement
     static final String BUNDLE_EXTRA_BUTTON_KEEP = "BUNDLE_EXTRA_BUTTON_KEEP";
     static final String BUNDLE_EXTRA_IMAGE_URI = "BUNDLE_EXTRA_IMAGE_URI";
     static final String BUNDLE_EXTRA_TITLE = "BUNDLE_EXTRA_TITLE";
+    static final int RESULT_CODE_KEEP = 1;
+    static final int RESULT_CODE_DISCARD = 2;
     private static final String STATE_KEY_ROTATION = "STATE_KEY_ROTATION";
     private static final String STATE_KEY_VIEW_ROTATION = "STATE_KEY_VIEW_ROTATION";
     private View mHelpContainer;
@@ -41,7 +43,14 @@ final public class ReviewPictureActivity extends SwitchSdkBaseActivity implement
     private float mViewRotationInDegrees;
 
     @Override
-    public void finishReview() {
+    public void discardImageAndFinishReview() {
+        setResult(RESULT_CODE_DISCARD);
+        finish();
+    }
+
+    @Override
+    public void keepImageAndFinishReview() {
+        setResult(RESULT_CODE_KEEP);
         finish();
     }
 

--- a/switchsdk/src/main/java/net/gini/switchsdk/ReviewPictureContract.java
+++ b/switchsdk/src/main/java/net/gini/switchsdk/ReviewPictureContract.java
@@ -18,7 +18,9 @@ interface ReviewPictureContract {
 
     interface View {
 
-        void finishReview();
+        void discardImageAndFinishReview();
+
+        void keepImageAndFinishReview();
 
         void rotateViewAnimated();
 

--- a/switchsdk/src/main/java/net/gini/switchsdk/ReviewPicturePresenter.java
+++ b/switchsdk/src/main/java/net/gini/switchsdk/ReviewPicturePresenter.java
@@ -22,7 +22,7 @@ class ReviewPicturePresenter implements ReviewPictureContract.Presenter {
     @Override
     public void discardImage() {
         mDocumentService.deleteImage(mUri);
-        mView.finishReview();
+        mView.discardImageAndFinishReview();
     }
 
     @Override
@@ -42,7 +42,7 @@ class ReviewPicturePresenter implements ReviewPictureContract.Presenter {
         } else {
             mDocumentService.keepImage(mUri);
         }
-        mView.finishReview();
+        mView.keepImageAndFinishReview();
     }
 
     @Override

--- a/switchsdk/src/main/java/net/gini/switchsdk/TakePictureActivity.java
+++ b/switchsdk/src/main/java/net/gini/switchsdk/TakePictureActivity.java
@@ -69,6 +69,7 @@ final public class TakePictureActivity extends SwitchSdkBaseActivity implements
     private static final long ONBOARDING_ANIMATION_DURATION_IN_MS = 500;
     private static final int PERMISSIONS_REQUEST_CAMERA = 101;
     private static final String STATE_KEY_SELECTED_IMAGE = "STATE_KEY_SELECTED_IMAGE";
+    private static final int REQUEST_REVIEW = 1;
     private ImageAdapter mAdapter;
     private GiniCamera mCamera;
     private View mCameraFrame;
@@ -198,6 +199,17 @@ final public class TakePictureActivity extends SwitchSdkBaseActivity implements
                 (WindowManager) getSystemService(Context.WINDOW_SERVICE);
         mCamera = new Camera1(mCameraPreview);
         mCamera.setPreviewOrientation(windowManager.getDefaultDisplay().getRotation());
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == REQUEST_REVIEW) {
+            if (resultCode == ReviewPictureActivity.RESULT_CODE_KEEP) {
+                mPresenter.onPictureKept();
+            }
+        }
     }
 
     @Override
@@ -377,7 +389,7 @@ final public class TakePictureActivity extends SwitchSdkBaseActivity implements
         final IntentFactory switchSdkIntentFactory = new IntentFactory(
                 SwitchSdk.getSdk());
         final Intent intent = switchSdkIntentFactory.createReviewActivity(image.getUri());
-        startActivity(intent);
+        startActivityForResult(intent, REQUEST_REVIEW);
     }
 
     @Override

--- a/switchsdk/src/main/java/net/gini/switchsdk/TakePictureContract.java
+++ b/switchsdk/src/main/java/net/gini/switchsdk/TakePictureContract.java
@@ -21,6 +21,8 @@ interface TakePictureContract {
 
         void onImageSelected(final Image image);
 
+        void onPictureKept();
+
         void onPictureTaken(@NonNull final byte[] data, final int orientation);
 
         void onTakePictureSelected();

--- a/switchsdk/src/main/java/net/gini/switchsdk/TakePicturePresenter.java
+++ b/switchsdk/src/main/java/net/gini/switchsdk/TakePicturePresenter.java
@@ -94,13 +94,15 @@ class TakePicturePresenter implements TakePictureContract.Presenter,
                 new ExtractionService.ExtractionListener() {
                     @Override
                     public void onExtractionsReceived() {
-                        //Check if the user is in the camera screen
-                        if (canExitSdk()) {
-                            int resultCode = SwitchSdk.EXTRACTIONS_AVAILABLE;
-                            exitSdkWithCleanup(resultCode);
-                        }
                     }
                 });
+    }
+
+    @Override
+    public void onPictureKept() {
+        if (mExtractionService.extractionsAvailable()) {
+            exitSdkWithCleanup(SwitchSdk.EXTRACTIONS_AVAILABLE);
+        }
     }
 
     @Override
@@ -116,12 +118,6 @@ class TakePicturePresenter implements TakePictureContract.Presenter,
             mView.openTakePictureScreen();
             mView.showTakePictureButtons();
             mView.hidePreviewButtons();
-            //if there are extractions available we finish the sdk
-            if (mExtractionService.extractionsAvailable()) {
-                //TODO maybe add delay here
-                int resultCode = SwitchSdk.EXTRACTIONS_AVAILABLE;
-                exitSdkWithCleanup(resultCode);
-            }
         }
     }
 

--- a/switchsdk/src/test/java/net/gini/switchsdk/ReviewPicturePresenterTest.java
+++ b/switchsdk/src/test/java/net/gini/switchsdk/ReviewPicturePresenterTest.java
@@ -39,7 +39,7 @@ public class ReviewPicturePresenterTest {
                 mMockDocumentService, mMockUri);
         presenter.discardImage();
 
-        verify(mMockView).finishReview();
+        verify(mMockView).discardImageAndFinishReview();
     }
 
     @Test
@@ -57,7 +57,7 @@ public class ReviewPicturePresenterTest {
                 mMockDocumentService, mMockUri);
         presenter.keepImage();
 
-        verify(mMockView).finishReview();
+        verify(mMockView).keepImageAndFinishReview();
     }
 
     @Before


### PR DESCRIPTION
## Information
As discussed in the UX concept: in case all extractions are available,
only exit automatically if the user has taken (and also chosen) the next
picture.
## How to test
Take pictures of a document. The process should only exit after some picture was taken.